### PR TITLE
Create CODEOWNERS file for ojs team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @operationjobsearch/ojs


### PR DESCRIPTION
This adds a `CODEOWNERS` file for the ojs team so that code owners are assigned for review automatically. The file currently assigns anyone in the ojs team to review any changes to the repo without any rules for subdirectories.